### PR TITLE
fix makefile warnings

### DIFF
--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -28,7 +28,7 @@ default:: $(DEFAULT_HELP_TARGET)
 	@exit 0
 
 ## Help screen
-help:
+help::
 	@printf "Available targets:\n\n"
 	@$(SELF) -s help/generate | grep -E "\w($(HELP_FILTER))"
 


### PR DESCRIPTION
## What and Why
Projects can either have their own Makefile, or use the build-harness scheme.  Currently `backend` and `ordering` have a `help` target and also use build-harness.

The issue addressed by this PR: Makefiles that include a `help` target give us this very annoying warning when running `make` with any target (not just help):

```
Makefile:110: warning: overriding commands for target `help'
/Users/sheyman/Projects/backend/build-harness/Makefile.helpers:32: warning: ignoring old commands for target `help'
```

This can be fixed in several ways.  One is to rename each project's `help` target to something like `help-backend` or `help-ordering` but that isn't terribly attractive and you can't get the help from the build-harness provided targets.  A second way is to use the GNU `double-colon` on the target.  This changes the `override` to more of an `inheritance` approach so the `make help` command issued on backend will also show the help for build-harness.  The downside here is that all `help` targets need to use double-colon. 

This PR updates the build harness to change `help` target to use double-colon.  There are co-req PRs for [ordering](https://github.com/UnionPOS/ordering) and [backend](https://github.com/UnionPOS/backend).  This one should go first, then the others.  Without that orchestration, all `make XXX` will fail due to the mismatch between single and double colon (even if you aren't doing `make help`).

## Related Tickets and PRs

Fixes [UN-3058](https://tabbedout.atlassian.net/browse/UN-3058)

## Steps to Test

`make help` and verify no warning messages and the help appears correctly.
`make lint` or any other valid target and verify no error messages


## Humor for Reviewer
![image](https://user-images.githubusercontent.com/1700532/120514287-bbe63580-c392-11eb-8509-061b92850d5d.png)
