### PR TITLE
UN-5266 hardening bg cleanup

### DIFF
--- a/bashlib/aws/autoscaling.sh
+++ b/bashlib/aws/autoscaling.sh
@@ -24,9 +24,14 @@ function asg_attach_instances() {
   local ASG_NAME="$1"
   local INSTANCE_ID="$2"
 
-  aws autoscaling attach-instances \
-    --instance-ids "$INSTANCE_ID" \
-    --auto-scaling-group-name "$ASG_NAME"
+  if ec2_is_instance_running $INSTANCE_ID; then
+    aws autoscaling attach-instances \
+      --instance-ids "$INSTANCE_ID" \
+      --auto-scaling-group-name "$ASG_NAME"
+  else
+    echo "Instance $INSTANCE_ID not in running state, skipping"
+  fi
+
 }
 export -f asg_attach_instances
 
@@ -88,10 +93,15 @@ function asg_detach_instances() {
   local ASG_NAME="$1"
   local INSTANCE_ID="$2"
 
-  aws autoscaling detach-instances \
-    --instance-ids "$INSTANCE_ID" \
-    --auto-scaling-group-name "$ASG_NAME" \
-    --should-decrement-desired-capacity
+  if ec2_is_instance_running $INSTANCE_ID; then
+    aws autoscaling detach-instances \
+        --instance-ids "$INSTANCE_ID" \
+        --auto-scaling-group-name "$ASG_NAME" \
+        --should-decrement-desired-capacity
+  else
+    echo "Instance $INSTANCE_ID not in running state, skipping"
+  fi
+
 }
 export -f asg_detach_instances
 

--- a/bashlib/aws/ec2.sh
+++ b/bashlib/aws/ec2.sh
@@ -38,11 +38,32 @@ function ec2_private_ip() {
 }
 export -f ec2_private_ip
 
+function ec2_is_instance_running() {
+  local INSTANCE_ID="$1"
+
+  state=`aws ec2 describe-instance-status \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'InstanceStatuses[0].InstanceState.Name' \
+        --output text`
+  if [ $state == 'running' ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+export -f ec2_is_instance_running
+
 function terminate_instances() {
   local INSTANCE_ID="$1"
 
-  aws ec2 terminate-instances \
+  if ec2_is_instance_running $INSTANCE_ID; then
+    aws ec2 terminate-instances \
     --instance-ids "$INSTANCE_ID"
+  else
+    echo "Instance $INSTANCE_ID not in running state, skipping"
+  fi
 }
 export -f terminate_instances
+
 


### PR DESCRIPTION
## What and Why
Cleaning up b/g api 

## Related Tickets and PRs

Fixes [UN-5266](https://tabbedout.atlassian.net/browse/UN-5266)

## Steps to Test
Pull operations and build-harness changes. 
Cd out of and then back into operations repo. 
Scale QA api up to 2 instances.
Run api deploy in buildkite qa with `bluegreen=maybe`. 
Run b/g clean up command.
During deletion of api instances, terminate both instances after the first one starts terminating.
During detach for b/g instances, terminate the instance that has not been detached.
Confirm qa-api has 2 instances running at script completion and b/g asg is deleted.

## Humor for Reviewer
