### PR TITLE
UN_12365: fix for apple machines and lambda

### DIFF
--- a/bashlib/aws/lambda.sh
+++ b/bashlib/aws/lambda.sh
@@ -9,25 +9,13 @@ function lambda_invoke() {
   local region="${AWS_REGION:-"us-west-2"}"
   local results_file="lambda_invoke_result"
 
-  # Detect if the processor is ARM (includes Apple Silicon like M1, M2, M3)
-  if [[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]]; then
-    result="$(aws lambda invoke \
-      --invocation-type "$invocation_type" \
-      --function-name "$function_name" \
-      --region "$region" \
-      --log-type "$log_type" \
-      --cli-binary-format raw-in-base64-out \
-      --payload "$payload" \
-      "$results_file")"
-  else
-    result="$(aws lambda invoke \
-      --invocation-type "$invocation_type" \
-      --function-name "$function_name" \
-      --region "$region" \
-      --log-type "$log_type" \
-      --payload "$payload" \
-      "$results_file")"
-  fi
+  result="$(aws lambda invoke \
+    --invocation-type "$invocation_type" \
+    --function-name "$function_name" \
+    --region "$region" \
+    --log-type "$log_type" \
+    --payload "$payload" \
+    "$results_file")"
 
   if [[ -n ${DECODE:-} ]]
   then


### PR DESCRIPTION
## What and Why
Don't need to specify ` --cli-binary-format raw-in-base64-out ` with the latest AWS CLI v1, and its not an option anymore in AWS CLI v2.

v2 is available but not via pip, so if we want to move there then larger changes will be needed.  This is just a bandaid for v1.

## Related Tickets and PRs

Fixes [UN-12365](https://tabbedout.atlassian.net/browse/UN-12365

## Steps to Test


## Humor for Reviewer

[UN-12365]: https://tabbedout.atlassian.net/browse/UN-12365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ