### PR TITLE
UN-16505: Add payment-api to DevSandbox container picker menus

### DIFF
--- a/bashlib/sandbox.sh
+++ b/bashlib/sandbox.sh
@@ -31,6 +31,7 @@ function list_containers() {
   echo "14. MicroMDM"
   echo "15. Smithers"
   echo "16. FakeSSM"
+  echo "17. Payment API"
 }
 
 function instance_name_from_selection() {
@@ -66,6 +67,8 @@ function instance_name_from_selection() {
     15) instance=smithers.union
       ;;
     16) instance=fakessm.union
+      ;;
+    17) instance=payment-api.union
       ;;
     *)
       instance=""


### PR DESCRIPTION
## Summary
- Add **Payment API** (option 17 → `payment-api.union`) to `list_containers` and `instance_name_from_selection` in `bashlib/sandbox.sh`.
- Enables `bin/logs`, `bin/attach`, `bin/inspect`, `bin/stats`, and `bin/top` to target the new payment-api DevSandbox service.

Companion DevSandbox PR: https://github.com/UnionPOS/dev-sandbox/pull/298

## Test plan
- [ ] After merging, run `make update` (or `make init`) in DevSandbox to pull the new build-harness
- [ ] `bin/logs 17` tails `payment-api.union` logs
- [ ] `bin/attach 17` attaches to the running payment-api container

Jira: https://tabbedout.atlassian.net/browse/UN-16505

Made with [Cursor](https://cursor.com)